### PR TITLE
Fix: Redirect admin users to /admin/dashboard

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -28,6 +28,16 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
+        $user = Auth::user();
+
+        if ($user && method_exists($user, 'getRoleNames')) {
+            $roles = $user->getRoleNames();
+
+            if ($roles->contains('admin')) {
+                return redirect()->intended('/admin/dashboard');
+            }
+        }
+
         return redirect()->intended(route('dashboard', absolute: false));
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "coinvest",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -51,4 +51,36 @@ class AuthenticationTest extends TestCase
         $this->assertGuest();
         $response->assertRedirect('/');
     }
+
+    public function test_admin_can_authenticate_and_redirects_to_admin_dashboard(): void
+    {
+        // Run the UserSeeder to ensure the admin role and user exist
+        $this->seed(\Database\Seeders\UserSeeder::class);
+
+        $admin = User::where('email', 'admin@example.com')->first();
+
+        $response = $this->post('/login', [
+            'email' => 'admin@example.com',
+            'password' => 'password',
+        ]);
+
+        $this->assertAuthenticatedAs($admin);
+        $response->assertRedirect('/admin/dashboard');
+    }
+
+    public function test_non_admin_user_can_authenticate_and_redirects_to_dashboard(): void
+    {
+        // Run the UserSeeder to ensure the non-admin role and user exist
+        $this->seed(\Database\Seeders\UserSeeder::class);
+
+        $user = User::where('email', 'user@example.com')->first();
+
+        $response = $this->post('/login', [
+            'email' => 'user@example.com',
+            'password' => 'password',
+        ]);
+
+        $this->assertAuthenticatedAs($user);
+        $response->assertRedirect(route('dashboard', absolute: false));
+    }
 }


### PR DESCRIPTION
This commit resolves an issue where admin users were not being redirected to the /admin/dashboard after login.

The redirection logic was added directly to the `AuthenticatedSessionController@store` method. This ensures that:
- Admin users are redirected to `/admin/dashboard`.
- Non-admin users continue to be redirected to `/dashboard`.

Tests have been added to `AuthenticationTest.php` to cover both admin and non-admin login redirection scenarios, and all tests pass.

Note: This solution introduces some duplication of logic found in `App\Http\Responses\LoginResponse.php`. The `LoginResponse` class was intended to handle this, but it appears it was not being invoked correctly by the Fortify authentication flow in this application. The current change directly in the controller ensures the correct behavior. A future refactor could investigate deeper into Fortify's pipeline to ensure the `LoginResponse` is utilized as originally intended.